### PR TITLE
Fixed continue label invisible background on iOS7

### DIFF
--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -215,6 +215,7 @@ static const BOOL kEnableContinueLabel = YES;
             lblContinue.textAlignment = NSTextAlignmentCenter;
             lblContinue.text = @"Tap to continue";
             lblContinue.alpha = 0.0f;
+            lblContinue.backgroundColor = [UIColor whiteColor];
             [self addSubview:lblContinue];
             [UIView animateWithDuration:0.3f delay:1.0f options:0 animations:^{
                 lblContinue.alpha = 1.0f;


### PR DESCRIPTION
Fix for the issue #10 where the "tap to continue background" is not showing on iOS7
