### PR TITLE
add image view in coach view

### DIFF
--- a/WSCoachMarksView.h
+++ b/WSCoachMarksView.h
@@ -45,6 +45,7 @@
 @property (nonatomic, WS_WEAK) id<WSCoachMarksViewDelegate> delegate;
 @property (nonatomic, retain) NSArray *coachMarks;
 @property (nonatomic, retain) UILabel *lblCaption;
+@property (nonatomic, retain) UIImageView *lblImageView;
 @property (nonatomic, retain) UIColor *maskColor;
 @property (nonatomic) CGFloat animationDuration;
 @property (nonatomic) CGFloat cutoutRadius;


### PR DESCRIPTION
Add a "image" section in marker dict, it will
show a image view under the mask and above the
caption text.

It would be useful for adding some picture
in coach view.

TODO: Document.
