### PR TITLE
Adding support for attributed strings.

### DIFF
--- a/WSCoachMarksView.m
+++ b/WSCoachMarksView.m
@@ -190,7 +190,14 @@ static const BOOL kEnableSkipButton = YES;
     // Calculate the caption position and size
     self.lblCaption.alpha = 0.0f;
     self.lblCaption.frame = (CGRect){{0.0f, 0.0f}, {self.maxLblWidth, 0.0f}};
-    self.lblCaption.text = markCaption;
+    
+    if([markCaption isKindOfClass:[NSAttributedString class]]) {
+        self.lblCaption.attributedText = (NSAttributedString*)markCaption;
+    } else {
+        self.lblCaption.text = markCaption;
+    }
+
+    
     [self.lblCaption sizeToFit];
     CGFloat y = markRect.origin.y + markRect.size.height + self.lblSpacing;
     CGFloat bottomY = y + self.lblCaption.frame.size.height + self.lblSpacing;


### PR DESCRIPTION
When setting the caption value of a coach mark an `NSAttributedString` can be passed as well as a regular `NSString` and the appropriate label property will be set accordingly. This allows labels with different fonts, text colors, etc to be displayed if needed.